### PR TITLE
hotfix: fix incorrect redirect link

### DIFF
--- a/docs/3.-quick-start.md
+++ b/docs/3.-quick-start.md
@@ -5,7 +5,7 @@ hide_title: true
 
 To quickly start, let's try something live online.. [REQ|RES](https://reqres.in) is a hosted demo REST api service. Let's call a simple API endpoint from here.
 
-> First [setup chkware](2.-Setup).
+> First [setup chkware](setup).
 
 Go to https://reqres.in, and find there is an endpoint like **_GET_ SINGLE USER** we'll call this API with Chkware. So, follow these steps:
 


### PR DESCRIPTION
Fix #19.

I forgot to change the redirect link in `3.-quick-start.md`. As the config states `onBrokenLinks: 'throw'`, the pipeline was failing.