### PR TITLE
feat: deploy to GitHub Pages using custom `GitHub Actions`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,20 +5,33 @@ on:
     branches:
       - main
 
+    workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  deploy:
-    name: Deploy to GitHub Pages
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      - name: Set up Node
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          cache: 'npm'
+          cache-dependency-path: ./package-lock.json
 
-      - name: Cache dependencies
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Restore cache
         uses: actions/cache@v3
         with:
           path: |
@@ -28,13 +41,22 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
+      - name: Build with docusaurus
         run: npm run build
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
-          user_name: github-actions[bot]
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          path: ./build
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
Close #47.

The updated workflow removes the 3rd party action `peaceiris/actions-gh-pages@v3` and uses the official GitHub actions. Also, previously the `cname` was to be [specified in the actions](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-add-cname-file-cname) and also in the `Settings ➜ Pages ➜ Custom domain`. But now the cname should not need to be included in the action file.

## Changes to be made in repo settings

Currently, the `page` is being published using source **Deploy from a branch**. 

That needs to be changed to `GitHub Actions` by visiting Settings ➜ Pages ➜ Build and deployment.

<img width="467" alt="image" src="https://user-images.githubusercontent.com/45073703/220047759-55682bcb-aa41-4e7a-a22d-474b1eed9795.png">
